### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/


### PR DESCRIPTION
Node modules is recommended to be ignored per proper web standards. You don’t want to version control someone else’s code in your code.